### PR TITLE
Updated wavefront-proxy version tag to 11.3

### DIFF
--- a/wavefront-proxy/wavefront.yaml
+++ b/wavefront-proxy/wavefront.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: wavefront-proxy
-          image: projects.registry.vmware.com/tanzu_observability/proxy:11.0
+          image: projects.registry.vmware.com/tanzu_observability/proxy:11.3
           imagePullPolicy: IfNotPresent
           env:
             - name: WAVEFRONT_URL


### PR DESCRIPTION
Just a simple update to the latest released version of wavefront-proxy 