### PR TITLE
Release Docker Image for new release of telegraf - v1.24.2 to docker hub 

### DIFF
--- a/docker-images/telegraf-sidecar/Dockerfile
+++ b/docker-images/telegraf-sidecar/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used in a sidecar config
 
-FROM telegraf:1.23.0
+FROM telegraf:1.24.2
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878

--- a/docker-images/telegraf-sidecar/alpine/Dockerfile
+++ b/docker-images/telegraf-sidecar/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used in a sidecar config
 
-FROM telegraf:1.23.0-alpine
+FROM telegraf:1.24.2-alpine
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878

--- a/docker-images/telegraf/Dockerfile
+++ b/docker-images/telegraf/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used as it's own deployment to collect metrics
 
-FROM telegraf:1.23.0
+FROM telegraf:1.24.2
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878

--- a/docker-images/telegraf/alpine/Dockerfile
+++ b/docker-images/telegraf/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used as it's own deployment to collect metrics
 
-FROM telegraf:1.23.0-alpine
+FROM telegraf:1.24.2-alpine
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878


### PR DESCRIPTION
We have new release version of telegraf v1.24.2 - https://github.com/influxdata/telegraf/releases