### PR TITLE
Release docker image for telegraf v1.28.2

### DIFF
--- a/docker-images/telegraf-sidecar/Dockerfile
+++ b/docker-images/telegraf-sidecar/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used in a sidecar config
 
-FROM telegraf:1.24.2
+FROM telegraf:1.28.2
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878

--- a/docker-images/telegraf-sidecar/alpine/Dockerfile
+++ b/docker-images/telegraf-sidecar/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used in a sidecar config
 
-FROM telegraf:1.24.2-alpine
+FROM telegraf:1.28.2-alpine
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878

--- a/docker-images/telegraf/Dockerfile
+++ b/docker-images/telegraf/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used as it's own deployment to collect metrics
 
-FROM telegraf:1.24.2
+FROM telegraf:1.28.2
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878

--- a/docker-images/telegraf/alpine/Dockerfile
+++ b/docker-images/telegraf/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # Telegraf agent configured for Wavefront output intended to be used as it's own deployment to collect metrics
 
-FROM telegraf:1.24.2-alpine
+FROM telegraf:1.28.2-alpine
 
 ENV WAVEFRONT_PROXY=wavefront-proxy
 ENV WAVEFRONT_PROXY_PORT=2878


### PR DESCRIPTION
Release docker image for telegraf v1.28.2 - [INT-1991 ](https://jira.eng.vmware.com/browse/INT-1991)